### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,24 @@
+# Documentation Index
+
+- [](&)Documentation/AnimationBestPracticesGuide.md
+- [](&)Documentation/AnimationMasterclassManagerAPI.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/BasicAnimationAPI.md
+- [](&)Documentation/BasicAnimationGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/GestureAnimationAPI.md
+- [](&)Documentation/GestureAnimationGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/KeyframeAnimationAPI.md
+- [](&)Documentation/KeyframeAnimationGuide.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/SpringAnimationAPI.md
+- [](&)Documentation/SpringAnimationGuide.md
+- [](&)Documentation/TransitionAPI.md
+- [](&)Documentation/TransitionGuide.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,9 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/BasicAnimationExamples/BasicAnimationExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/BasicAnimationExample.swift
+- ``Examples/KeyframeAnimationExamples/KeyframeAnimationExample.swift
+- ``Examples/SpringAnimationExamples/SpringAnimationExample.swift
+- ``Examples/TransitionExamples/TransitionExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.